### PR TITLE
closes #9 - resolve host names into ip addresses. (low priority)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ FROM ubuntu:16.04
 WORKDIR /app
 
 RUN apt-get update -y
-RUN apt-get -y install curl
+RUN apt-get -y install curl dnsutils libsodium-dev netcat git make g++
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
-RUN apt-get install -y nodejs libsodium-dev netcat git make g++
-
+RUN apt-get install -y nodejs
 
 # Copy the current directory contents into the container at /app
 ADD . /app

--- a/startQuorum.sh
+++ b/startQuorum.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-echo "in the start qnm script"
+# These variables must be ip addresses - resolve them if they are host names
+if [[ -n "$DEPENDENT_IP" && ! $DEPENDENT_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  DEPENDENT_IP=$(host $DEPENDENT_IP | awk '/has address/ { print $4 }')
+fi
+if [[ -n "$COORDINATING_IP" && ! $COORDINATING_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  COORDINATING_IP=$(host $COORDINATING_IP | awk '/has address/ { print $4 }')
+fi
+if [[ -n "$IP" && ! $IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  IP=$(host $IP | awk '/has address/ { print $4 }')
+fi
+
 cd /app/QuorumNetworkManager
 if [ -n "$DEPENDENT_IP" ]; then PORT=20010 HOST_IP=$DEPENDENT_IP ../waitForOtherNode.sh; fi
 KEEP_FILES=false NODE_NAME=node1 CONSENSUS=istanbul node setupFromConfig.js


### PR DESCRIPTION
Now multinode quorum networks can be defined by docker-compose files without specifying ip addresses (just host names). This change is backwards compatible.

Please look at the docker-compose files for cash-tokenizer-ui to see it in action. 